### PR TITLE
Change id of `Yes` radio

### DIFF
--- a/src/main/scala/uk/gov/hmrc/viewmodels/Radios.scala
+++ b/src/main/scala/uk/gov/hmrc/viewmodels/Radios.scala
@@ -41,7 +41,7 @@ object Radios {
   }
 
   def yesNo(field: Field)(implicit messages: Messages): Seq[Item] = Seq(
-    Item(id = s"${field.id}-yes", text = msg"site.yes", value = "true", checked = field.value.contains("true")),
+    Item(id = field.id, text = msg"site.yes", value = "true", checked = field.value.contains("true")),
     Item(id = s"${field.id}-no", text = msg"site.no", value = "false", checked = field.value.contains("false"))
   )
 }


### PR DESCRIPTION
When forms are in an error state, the Error Summary component will
contain links to the field which uses the field's id.  For radios,
it should target the first option (`Yes` in the case of Yes/No
radios).  Setting the id of the first option to equal the name of
the field makes producing this link correctly much easier.